### PR TITLE
specify namespace on list operation

### DIFF
--- a/pkg/storage/kubernetes.go
+++ b/pkg/storage/kubernetes.go
@@ -145,7 +145,7 @@ func (i *KubernetesIPAM) getPool(ctx context.Context, name string, iprange strin
 // Status tests connectivity to the kubernetes backend
 func (i *KubernetesIPAM) Status(ctx context.Context) error {
 	list := &whereaboutsv1alpha1.IPPoolList{}
-	err := i.client.List(ctx, list)
+	err := i.client.List(ctx, list, &client.ListOptions{Namespace: i.namespace})
 	return err
 }
 


### PR DESCRIPTION
The namespace should be passed to the list operation in case the whereabouts plugin is given a Rolebinding instead of a ClusterRolebinding. (Working on a helm chart with limited privileges)