### PR TITLE
range_end should be treated as inclusive when iterating for ip assignments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/go-logr/logr v0.1.0
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/google/btree v1.0.0 // indirect
 	github.com/google/uuid v1.1.1 // indirect

--- a/pkg/allocate/allocate.go
+++ b/pkg/allocate/allocate.go
@@ -66,7 +66,9 @@ func IterateForAssignment(ipnet net.IPNet, rangeStart net.IP, rangeEnd net.IP, r
 	firstip := rangeStart
 	var lastip net.IP
 	if rangeEnd != nil {
-		lastip = rangeEnd
+		end := IPToBigInt(rangeEnd)
+		end = end.Add(end, big.NewInt(1))
+		lastip = BigIntToIP(*end)
 	} else {
 		var err error
 		_, lastip, err = GetIPRange(rangeStart, ipnet)


### PR DESCRIPTION
Offset the `range_end` IP by one so that the subnet range is inclusive. This makes more sense, and I think is what I intended. `range_start` is inclusive, whereas this wasn't.

Resolves #35