### PR TITLE
Make ds use hostNetwork by default

### DIFF
--- a/doc/daemonset-install.yaml
+++ b/doc/daemonset-install.yaml
@@ -57,6 +57,7 @@ spec:
         app: whereabouts
         name: whereabouts
     spec:
+      hostNetwork: true      
       serviceAccountName: whereabouts
       nodeSelector:
         beta.kubernetes.io/arch: amd64


### PR DESCRIPTION
This patch makes whereabouts pods deployed as ds to use
hostNetwork by default. This is helpful as CNI and core
infra components use hostnetwork and hence avoid issues
such as fault in CNI config etc and also making debugging
much easier.