### PR TITLE
Change error message

### DIFF
--- a/cmd/whereabouts.go
+++ b/cmd/whereabouts.go
@@ -40,8 +40,8 @@ func cmdAdd(args *skel.CmdArgs) error {
 	logging.Debugf("Beginning IPAM for ContainerID: %v", args.ContainerID)
 	newip, err := storage.IPManagement(types.Allocate, *ipamConf, args.ContainerID)
 	if err != nil {
-		logging.Errorf("Error assigning IP: %s", err)
-		return fmt.Errorf("Error assigning IP: %w", err)
+		logging.Errorf("Error at storage engine: %s", err)
+		return fmt.Errorf("Error at storage engine: %w", err)
 	}
 
 	// Determine if v4 or v6.

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -56,7 +56,7 @@ func IPManagement(mode int, ipamConf types.IPAMConfig, containerID string) (net.
 	}
 	if err != nil {
 		logging.Errorf("IPAM %s client initialization error: %v", ipamConf.Datastore, err)
-		return newip, err
+		return newip, fmt.Errorf("IPAM %s client initialization error: %v", ipamConf.Datastore, err)
 	}
 	defer ipam.Close()
 


### PR DESCRIPTION
This changes checks kubeconfig existence at loading IPAM config to cause appropreate error message when kubeconfig is not exist in case of kubernetes CRD mode.

Error message is:
```
You have not configured the storage engine (looks like you're using an invalid `kubernetes.kubeconfig` as stat /etc/cni/net.d/whereabouts.d/whereabouts.kubeconfig: no such file or directory parameter in your config)
```