### PR TITLE
Specifiy image repo URL explicitly

### DIFF
--- a/doc/daemonset-install.yaml
+++ b/doc/daemonset-install.yaml
@@ -66,7 +66,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: whereabouts
-        image: dougbtv/whereabouts:latest
+        image: docker.io/dougbtv/whereabouts:latest
         env:
         - name: WHEREABOUTS_NAMESPACE
           valueFrom:


### PR DESCRIPTION
This fix supplies domain for container image repo because
in some runtime configuration, 'docker.io' is not specified as
default container repository url.