### PR TITLE
Create Whereabouts flatfile config by default

### DIFF
--- a/script/install-cni.sh
+++ b/script/install-cni.sh
@@ -18,6 +18,7 @@ CNI_CONF_DIR=${CNI_CONF_DIR:-"/host/etc/cni/net.d"}
 
 mkdir -p $CNI_CONF_DIR/whereabouts.d
 WHEREABOUTS_KUBECONFIG=$CNI_CONF_DIR/whereabouts.d/whereabouts.kubeconfig
+WHEREABOUTS_FLATFILE=$CNI_CONF_DIR/whereabouts.d/whereabouts.conf
 
 # ------------------------------- Generate a "kube-config"
 SERVICE_ACCOUNT_PATH=/var/run/secrets/kubernetes.io/serviceaccount
@@ -68,6 +69,19 @@ contexts:
     user: whereabouts
     namespace: ${WHEREABOUTS_NAMESPACE}
 current-context: whereabouts-context
+EOF
+
+  touch $WHEREABOUTS_FLATFILE
+  chmod ${KUBECONFIG_MODE:-600} $WHEREABOUTS_FLATFILE
+  cat > $WHEREABOUTS_FLATFILE <<EOF
+{
+  "datastore": "kubernetes",
+  "kubernetes": {
+    "kubeconfig": "${WHEREABOUTS_KUBECONFIG}"
+  },
+  "log_file": "/tmp/whereabouts.log",
+  "log_level": "debug"
+}
 EOF
 
 else


### PR DESCRIPTION
The install_cni.sh script already creates a .kubeconfig file and places it in /etc/cni/net.d/whereabouts.d/

So why not just go ahead and create the default whereabouts.conf that refers to this as well?

`{
  "datastore": "kubernetes",
  "kubernetes": {
    "kubeconfig": "/etc/cni/net.d/whereabouts.d/whereabouts.kubeconfig"
  },
  "log_file": "/tmp/whereabouts.log",
  "log_level": "debug"
}`

As the documentation states:

>  Whereabouts will look for the configuration in these locations, in this order:
> 
>      - The location specified by the configuration_path option.
>      - /etc/kubernetes/cni/net.d/whereabouts.d/whereabouts.conf
>      - /etc/cni/net.d/whereabouts.d/whereabouts.conf

If that's the case, this default whereabouts.conf file can already be overridden by the first two options. Or, this file has to be manually created by the user. If they're going to do that anyways they can just edit this JSON file or replace it themselves. I don't see any downside in including this, and it will just make standard Kubernetes datastore deployments that much easier.

FYI I did this in a private local branch myself, rebuilt the whereabouts Docker image, and am using that. I then changed the deployment manifest to use my container image instead, when I deployed all my nodes had this file by default. Simplified it a ton/saved me time, as otherwise I would've had to scp this file over to each box.

Another option to fix would perhaps be in the code itself. If these options are missing from IPAM section of NetworkAttachmentDefintion, AND all 3 of those flatfile options are missing - just set some const defaults, setting datastore to kubernetes, the kubeconfig file to the one we already pre-create, and logging to /tmp/, etc...

Fixes #57 