### PR TITLE
feat: add support multi-ranges

### DIFF
--- a/cmd/whereabouts.go
+++ b/cmd/whereabouts.go
@@ -38,7 +38,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	result.Routes = ipamConf.Routes
 
 	logging.Debugf("Beginning IPAM for ContainerID: %v", args.ContainerID)
-	newip, err := storage.IPManagement(types.Allocate, *ipamConf, args.ContainerID)
+	newip, gateway, err := storage.IPManagement(types.Allocate, *ipamConf, args.ContainerID)
 	if err != nil {
 		logging.Errorf("Error at storage engine: %s", err)
 		return fmt.Errorf("Error at storage engine: %w", err)
@@ -55,7 +55,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	result.IPs = append(result.IPs, &current.IPConfig{
 		Version: useVersion,
 		Address: newip,
-		Gateway: ipamConf.Gateway})
+		Gateway: gateway})
 
 	// Assign all the static IP elements.
 	for _, v := range ipamConf.Addresses {
@@ -77,7 +77,7 @@ func cmdDel(args *skel.CmdArgs) error {
 	logging.Debugf("DEL - IPAM configuration successfully read: %+v", filterConf(*ipamConf))
 	logging.Debugf("ContainerID: %v", args.ContainerID)
 
-	_, err = storage.IPManagement(types.Deallocate, *ipamConf, args.ContainerID)
+	_, _, err = storage.IPManagement(types.Deallocate, *ipamConf, args.ContainerID)
 	if err != nil {
 		logging.Errorf("Error deallocating IP: %s", err)
 		return fmt.Errorf("Error deallocating IP: %s", err)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -39,10 +39,11 @@ var _ = Describe("Allocation operations", func() {
 		Expect(ipamconfig.LogLevel).To(Equal("debug"))
 		Expect(ipamconfig.LogFile).To(Equal("/tmp/whereabouts.log"))
 		Expect(ipamconfig.EtcdHost).To(Equal("foo"))
-		Expect(ipamconfig.Range).To(Equal("192.168.1.0/24"))
-		Expect(ipamconfig.RangeStart).To(Equal(net.ParseIP("192.168.1.5")))
-		Expect(ipamconfig.RangeEnd).To(Equal(net.ParseIP("192.168.1.25")))
-		Expect(ipamconfig.Gateway).To(Equal(net.ParseIP("192.168.10.1")))
+		Expect(ipamconfig.Ranges).Should(HaveLen(1))
+		Expect(ipamconfig.Ranges[0].Range).To(Equal("192.168.1.0/24"))
+		Expect(ipamconfig.Ranges[0].RangeStart).To(Equal(net.ParseIP("192.168.1.5")))
+		Expect(ipamconfig.Ranges[0].RangeEnd).To(Equal(net.ParseIP("192.168.1.25")))
+		Expect(ipamconfig.Ranges[0].Gateway).To(Equal(net.ParseIP("192.168.10.1")))
 
 	})
 
@@ -79,13 +80,57 @@ var _ = Describe("Allocation operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipamconfig.LogLevel).To(Equal("debug"))
 		Expect(ipamconfig.LogFile).To(Equal("/tmp/whereabouts.log"))
-		Expect(ipamconfig.Range).To(Equal("192.168.2.0/24"))
-		Expect(ipamconfig.RangeStart.String()).To(Equal("192.168.2.223"))
+		Expect(ipamconfig.Ranges).Should(HaveLen(1))
+		Expect(ipamconfig.Ranges[0].Range).To(Equal("192.168.2.0/24"))
+		Expect(ipamconfig.Ranges[0].RangeStart.String()).To(Equal("192.168.2.223"))
 		// Gateway should remain unchanged from conf due to preference for primary config
-		Expect(ipamconfig.Gateway).To(Equal(net.ParseIP("192.168.10.1")))
+		Expect(ipamconfig.Ranges[0].Gateway).To(Equal(net.ParseIP("192.168.10.1")))
 		Expect(ipamconfig.Datastore).To(Equal("kubernetes"))
 		Expect(ipamconfig.Kubernetes.KubeConfigPath).To(Equal("/etc/cni/net.d/whereabouts.d/whereabouts.kubeconfig"))
 
+	})
+
+	It("can load ranges array", func() {
+		conf := `{
+      "cniVersion": "0.3.1",
+      "name": "mynet",
+      "type": "ipvlan",
+      "master": "foo0",
+      "ipam": {
+        "configuration_path": "/tmp/whereabouts.conf",
+        "type": "whereabouts",
+        "ranges": [ 
+          {
+            "range": "192.168.2.230/24",
+            "range_start": "192.168.2.223",
+			"range_end": "192.168.2.224",
+            "gateway": "192.168.10.1"
+          },
+          {
+            "range": "192.168.2.230/24",
+            "range_start": "192.168.2.226",
+			"range_end": "192.168.2.227",
+            "gateway": "192.168.10.1"
+          }
+        ]
+      }
+      }`
+
+		ipamconfig, _, err := LoadIPAMConfig([]byte(conf), "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ipamconfig.LogLevel).To(Equal("debug"))
+		Expect(ipamconfig.LogFile).To(Equal("/tmp/whereabouts.log"))
+		Expect(ipamconfig.Ranges).Should(HaveLen(2))
+		Expect(ipamconfig.Ranges[0].Range).To(Equal("192.168.2.0/24"))
+		Expect(ipamconfig.Ranges[0].RangeStart.String()).To(Equal("192.168.2.223"))
+		Expect(ipamconfig.Ranges[0].RangeEnd.String()).To(Equal("192.168.2.224"))
+		Expect(ipamconfig.Ranges[0].Gateway).To(Equal(net.ParseIP("192.168.10.1")))
+		Expect(ipamconfig.Ranges[1].Range).To(Equal("192.168.2.0/24"))
+		Expect(ipamconfig.Ranges[1].RangeStart.String()).To(Equal("192.168.2.226"))
+		Expect(ipamconfig.Ranges[1].RangeEnd.String()).To(Equal("192.168.2.227"))
+		Expect(ipamconfig.Ranges[1].Gateway).To(Equal(net.ParseIP("192.168.10.1")))
+		Expect(ipamconfig.Datastore).To(Equal("kubernetes"))
+		Expect(ipamconfig.Kubernetes.KubeConfigPath).To(Equal("/etc/cni/net.d/whereabouts.d/whereabouts.kubeconfig"))
 	})
 
 })

--- a/pkg/storage/etcd.go
+++ b/pkg/storage/etcd.go
@@ -49,7 +49,7 @@ func NewETCDIPAM(ipamConf types.IPAMConfig) (*ETCDIPAM, error) {
 	if err != nil {
 		return nil, err
 	}
-	mutex := concurrency.NewMutex(session, fmt.Sprintf("%s/%s", whereaboutsPrefix, ipamConf.Range))
+	mutex := concurrency.NewMutex(session, fmt.Sprintf("%s/%s", whereaboutsPrefix, ipamConf.Name))
 
 	// acquire our lock
 	if err := mutex.Lock(context.Background()); err != nil {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -33,6 +33,7 @@ type IPAMConfig struct {
 	RangeStart        net.IP            `json:"range_start,omitempty"`
 	RangeEnd          net.IP            `json:"range_end,omitempty"`
 	GatewayStr        string            `json:"gateway"`
+	Ranges            []IPRange         `json:"ranges"`
 	EtcdHost          string            `json:"etcd_host,omitempty"`
 	EtcdUsername      string            `json:"etcd_username,omitempty"`
 	EtcdPassword      string            `json:"etcd_password,omitempty"`
@@ -71,6 +72,15 @@ type Address struct {
 type IPReservation struct {
 	IP          net.IP `json:"ip"`
 	ContainerID string `json:"id"`
+}
+
+type IPRange struct {
+	Range      string `json:"range"`
+	RangeStart net.IP `json:"range_start,omitempty"`
+	RangeEnd   net.IP `json:"range_end,omitempty"`
+	GatewayStr string `json:"gateway"`
+	Gateway    net.IP
+	OmitRanges []string `json:"exclude,omitempty"`
 }
 
 const (


### PR DESCRIPTION
There is three breaking changes:
1. ETCD store lock name
2. Name of kubernetes resource for pool
3. Replace ip offset in CRD to IP strings