### PR TITLE
Fixing wrong DNS-1123 name for some IPv6 addresses

### DIFF
--- a/cmd/whereabouts_test.go
+++ b/cmd/whereabouts_test.go
@@ -128,6 +128,7 @@ var _ = Describe("Whereabouts operations", func() {
 		expectedAddress = "2001::1/116"
 
 		AllocateAndReleaseAddressesTest(ipVersion, ipRange, ipGateway, []string{expectedAddress}, whereaboutstypes.DatastoreETCD)
+
 	})
 
 	It("allocates and releases addresses on ADD/DEL with a Kubernetes backend", func() {
@@ -159,6 +160,17 @@ var _ = Describe("Whereabouts operations", func() {
 		expectedAddress = "2001::1/116"
 
 		AllocateAndReleaseAddressesTest(ipVersion, ipRange, ipGateway, []string{expectedAddress}, whereaboutstypes.DatastoreKubernetes)
+	})
+
+	It("allocates IPv6 addresses with DNS-1123 conformant naming with a Kubernetes backend", func() {
+
+		ipVersion := "6"
+		ipRange := "fd00:0:0:10:0:0:3:1-fd00:0:0:10:0:0:3:6/64"
+		ipGateway := "2001::f:1"
+		expectedAddress := "fd00:0:0:10:0:0:3:1/64"
+
+		AllocateAndReleaseAddressesTest(ipVersion, ipRange, ipGateway, []string{expectedAddress}, whereaboutstypes.DatastoreKubernetes)
+
 	})
 
 	It("excludes a range of addresses", func() {

--- a/pkg/storage/kubernetes.go
+++ b/pkg/storage/kubernetes.go
@@ -101,7 +101,7 @@ func toAllocationMap(reservelist []whereaboutstypes.IPReservation, firstip net.I
 // GetIPPool returns a storage.IPPool for the given range
 func (i *KubernetesIPAM) GetIPPool(ctx context.Context, ipRange string) (IPPool, error) {
 	// v6 filter
-	normalized := strings.ReplaceAll(ipRange, "::", "-")
+	normalized := strings.ReplaceAll(ipRange, ":", "-")
 	// replace subnet cidr slash
 	normalized = strings.ReplaceAll(normalized, "/", "-")
 
@@ -192,7 +192,7 @@ func (p *KubernetesIPPool) Update(ctx context.Context, reservations []whereabout
 	// add additional tests to the patch
 	ops := []jsonpatch.Operation{
 		// ensure patch is applied to appropriate resource version only
-		jsonpatch.Operation{Operation: "test", Path: "/metadata/resourceVersion", Value: orig.ObjectMeta.ResourceVersion},
+		{Operation: "test", Path: "/metadata/resourceVersion", Value: orig.ObjectMeta.ResourceVersion},
 	}
 	for _, o := range patch {
 		// safeguard add ops -- "add" will update existing paths, this "test" ensures the path is empty


### PR DESCRIPTION
When there was a single `:` in IPv6, this didn't work properly. This updates a `ReplaceAll` call to address this, so one can use more detailed IPv6 ranges.

Fixes https://github.com/openshift/whereabouts-cni/issues/20