### PR TITLE
Add a more meaningful error for invalid CIDR

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -108,7 +108,7 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*types.IPAMConfig, string, er
 		}
 		lastip, ipNet, err := net.ParseCIDR(r[1])
 		if err != nil {
-			return nil, "", fmt.Errorf("invalid CIDR %s: %s", r[1], err)
+			return nil, "", fmt.Errorf("invalid CIDR (do you have the 'range' parameter set for Whereabouts?) '%s': %s", r[1], err)
 		}
 		if !ipNet.Contains(firstip) {
 			return nil, "", fmt.Errorf("invalid range start for CIDR %s: %s", ipNet.String(), firstip)


### PR DESCRIPTION
To be more actionable and check if there is a `range` parameter set.