### PR TITLE
Excluded subnet handling for ipv6

### DIFF
--- a/pkg/allocate/allocate.go
+++ b/pkg/allocate/allocate.go
@@ -130,7 +130,7 @@ MAINITERATION:
 
 		// Lastly, we need to check if this IP is within the range of excluded subnets
 		for _, subnet := range excluded {
-			if subnet.Contains(BigIntToIP(*i).To4()) {
+			if subnet.Contains(BigIntToIP(*i).To16()) {
 				continue MAINITERATION
 			}
 		}


### PR DESCRIPTION
Excluded subnets was handled for ipv4. This fix handles ipv6 as well.

Fixes dougbtv/whereabouts#71