### PR TITLE
Removes error when deallocating IP errors out, instead just warns.

### DIFF
--- a/cmd/whereabouts.go
+++ b/cmd/whereabouts.go
@@ -79,8 +79,8 @@ func cmdDel(args *skel.CmdArgs) error {
 
 	_, err = storage.IPManagement(types.Deallocate, *ipamConf, args.ContainerID)
 	if err != nil {
-		logging.Errorf("Error deallocating IP: %s", err)
-		return fmt.Errorf("Error deallocating IP: %s", err)
+		logging.Verbosef("WARNING: Problem deallocating IP: %s", err)
+		// return fmt.Errorf("Error deallocating IP: %s", err)
 	}
 
 	return nil


### PR DESCRIPTION
@crandles any thoughts on this one?

I've gotten a few reports about a pod being in stuck creating when a range gets exhausted.

* https://github.com/kubernetes/kubernetes/issues/96200
* https://github.com/intel/multus-cni/issues/578
* https://github.com/dougbtv/whereabouts/issues/70

Overall, I think it's generally more correct... The gist is we get into a kind of loop when we have a situation where there's CNI ADD "no IP address there.... error out" and then CNI DEL "...error, because I never allocated an IP". I think CNI DEL in that case should instead be a warning, and not exit with an error.

Fixes #70 