### PR TITLE
[backport] Removes error when deallocating IP errors out, instead just warns.

### DIFF
--- a/cmd/whereabouts.go
+++ b/cmd/whereabouts.go
@@ -79,8 +79,8 @@ func cmdDel(args *skel.CmdArgs) error {
 
 	_, err = storage.IPManagement(types.Deallocate, *ipamConf, args.ContainerID)
 	if err != nil {
-		logging.Errorf("Error deallocating IP: %s", err)
-		return fmt.Errorf("Error deallocating IP: %s", err)
+		logging.Verbosef("WARNING: Problem deallocating IP: %s", err)
+		// return fmt.Errorf("Error deallocating IP: %s", err)
 	}
 
 	return nil


### PR DESCRIPTION
Backport to release-v0.4 branch for OpenShift. 