### PR TITLE
Enrich the IP allocation data structure to store the Pod reference

### DIFF
--- a/cmd/whereabouts.go
+++ b/cmd/whereabouts.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/containernetworking/cni/pkg/skel"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
@@ -38,7 +39,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	result.Routes = ipamConf.Routes
 
 	logging.Debugf("Beginning IPAM for ContainerID: %v", args.ContainerID)
-	newip, err := storage.IPManagement(types.Allocate, *ipamConf, args.ContainerID)
+	newip, err := storage.IPManagement(types.Allocate, *ipamConf, args.ContainerID, getPodRef(args.Args))
 	if err != nil {
 		logging.Errorf("Error at storage engine: %s", err)
 		return fmt.Errorf("Error at storage engine: %w", err)
@@ -77,7 +78,7 @@ func cmdDel(args *skel.CmdArgs) error {
 	logging.Debugf("DEL - IPAM configuration successfully read: %+v", filterConf(*ipamConf))
 	logging.Debugf("ContainerID: %v", args.ContainerID)
 
-	_, err = storage.IPManagement(types.Deallocate, *ipamConf, args.ContainerID)
+	_, err = storage.IPManagement(types.Deallocate, *ipamConf, args.ContainerID, getPodRef(args.Args))
 	if err != nil {
 		logging.Verbosef("WARNING: Problem deallocating IP: %s", err)
 		// return fmt.Errorf("Error deallocating IP: %s", err)
@@ -90,4 +91,25 @@ func filterConf(conf types.IPAMConfig) types.IPAMConfig {
 	new := conf
 	new.EtcdPassword = "*********"
 	return new
+}
+
+// GetPodRef constructs the PodRef string from CNI arguments.
+// It returns an empty string, if K8S_POD_NAMESPACE & K8S_POD_NAME arguments are not provided.
+func getPodRef(args string) string {
+	podNs := ""
+	podName := ""
+
+	for _, arg := range strings.Split(args, ";") {
+		if strings.HasPrefix(arg, "K8S_POD_NAMESPACE=") {
+			podNs = strings.TrimPrefix(arg, "K8S_POD_NAMESPACE=")
+		}
+		if strings.HasPrefix(arg, "K8S_POD_NAME=") {
+			podName = strings.TrimPrefix(arg, "K8S_POD_NAME=")
+		}
+	}
+
+	if podNs != "" && podName != "" {
+		return podNs + "/" + podName
+	}
+	return ""
 }

--- a/cmd/whereabouts_test.go
+++ b/cmd/whereabouts_test.go
@@ -58,6 +58,7 @@ func AllocateAndReleaseAddressesTest(ipVersion string, ipRange string, ipGateway
 			Netns:       nspath,
 			IfName:      ifname,
 			StdinData:   []byte(conf),
+			Args:        "IgnoreUnknown=1;K8S_POD_NAMESPACE=dummyNS;K8S_POD_NAME=dummyPOD",
 		}
 
 		// Allocate the IP

--- a/pkg/allocate/allocate.go
+++ b/pkg/allocate/allocate.go
@@ -21,12 +21,12 @@ func (a AssignmentError) Error() string {
 }
 
 // AssignIP assigns an IP using a range and a reserve list.
-func AssignIP(ipamConf types.IPAMConfig, reservelist []types.IPReservation, containerID string) (net.IPNet, []types.IPReservation, error) {
+func AssignIP(ipamConf types.IPAMConfig, reservelist []types.IPReservation, containerID string, podRef string) (net.IPNet, []types.IPReservation, error) {
 
 	// Setup the basics here.
 	_, ipnet, _ := net.ParseCIDR(ipamConf.Range)
 
-	newip, updatedreservelist, err := IterateForAssignment(*ipnet, ipamConf.RangeStart, ipamConf.RangeEnd, reservelist, ipamConf.OmitRanges, containerID)
+	newip, updatedreservelist, err := IterateForAssignment(*ipnet, ipamConf.RangeStart, ipamConf.RangeEnd, reservelist, ipamConf.OmitRanges, containerID, podRef)
 	if err != nil {
 		return net.IPNet{}, nil, err
 	}
@@ -170,7 +170,7 @@ func IPAddOffset(ip net.IP, offset uint64) net.IP {
 }
 
 // IterateForAssignment iterates given an IP/IPNet and a list of reserved IPs
-func IterateForAssignment(ipnet net.IPNet, rangeStart net.IP, rangeEnd net.IP, reservelist []types.IPReservation, excludeRanges []string, containerID string) (net.IP, []types.IPReservation, error) {
+func IterateForAssignment(ipnet net.IPNet, rangeStart net.IP, rangeEnd net.IP, reservelist []types.IPReservation, excludeRanges []string, containerID string, podRef string) (net.IP, []types.IPReservation, error) {
 	firstip := rangeStart
 	var lastip net.IP
 	if rangeEnd != nil {
@@ -223,7 +223,7 @@ func IterateForAssignment(ipnet net.IPNet, rangeStart net.IP, rangeEnd net.IP, r
 
 		assignedip = i
 		logging.Debugf("Reserving IP: |%v|", assignedip.String()+" "+containerID)
-		reservelist = append(reservelist, types.IPReservation{IP: assignedip, ContainerID: containerID})
+		reservelist = append(reservelist, types.IPReservation{IP: assignedip, ContainerID: containerID, PodRef: podRef})
 		break
 	}
 

--- a/pkg/allocate/allocate_test.go
+++ b/pkg/allocate/allocate_test.go
@@ -259,7 +259,7 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		var exrange []string
-		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef")
+		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
 		Expect(fmt.Sprint(newip)).To(Equal("192.168.1.1"))
 
 	})
@@ -274,7 +274,7 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		var exrange []string
-		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef")
+		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
 		Expect(fmt.Sprint(newip)).To(Equal("caa5::1"))
 
 	})
@@ -289,7 +289,7 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		var exrange []string
-		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef")
+		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
 		Expect(fmt.Sprint(newip)).To(Equal("::1"))
 
 	})
@@ -306,7 +306,7 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		var exrange []string
-		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef")
+		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
 		Expect(fmt.Sprint(newip)).To(Equal("fd::1"))
 
 	})
@@ -321,7 +321,7 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		var exrange []string
-		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef")
+		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
 		Expect(fmt.Sprint(newip)).To(Equal("100::2:1"))
 
 	})

--- a/pkg/api/v1alpha1/ippool_types.go
+++ b/pkg/api/v1alpha1/ippool_types.go
@@ -23,6 +23,7 @@ func (i IPPool) ParseCIDR() (net.IP, *net.IPNet, error) {
 // IPAllocation represents metadata about the pod/container owner of a specific IP
 type IPAllocation struct {
 	ContainerID string `json:"id"`
+	PodRef      string `json:"podref,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/storage/kubernetes.go
+++ b/pkg/storage/kubernetes.go
@@ -80,7 +80,7 @@ func toIPReservationList(allocations map[string]whereaboutsv1alpha1.IPAllocation
 			continue
 		}
 		ip := allocate.IPAddOffset(firstip, uint64(numOffset))
-		reservelist = append(reservelist, whereaboutstypes.IPReservation{IP: ip, ContainerID: a.ContainerID})
+		reservelist = append(reservelist, whereaboutstypes.IPReservation{IP: ip, ContainerID: a.ContainerID, PodRef: a.PodRef})
 	}
 	return reservelist
 }
@@ -89,7 +89,7 @@ func toAllocationMap(reservelist []whereaboutstypes.IPReservation, firstip net.I
 	allocations := make(map[string]whereaboutsv1alpha1.IPAllocation)
 	for _, r := range reservelist {
 		index := allocate.IPGetOffset(r.IP, firstip)
-		allocations[fmt.Sprintf("%d", index)] = whereaboutsv1alpha1.IPAllocation{ContainerID: r.ContainerID}
+		allocations[fmt.Sprintf("%d", index)] = whereaboutsv1alpha1.IPAllocation{ContainerID: r.ContainerID, PodRef: r.PodRef}
 	}
 	return allocations
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -33,9 +33,9 @@ type Store interface {
 }
 
 // IPManagement manages ip allocation and deallocation from a storage perspective
-func IPManagement(mode int, ipamConf types.IPAMConfig, containerID string) (net.IPNet, error) {
+func IPManagement(mode int, ipamConf types.IPAMConfig, containerID string, podRef string) (net.IPNet, error) {
 
-	logging.Debugf("IPManagement -- mode: %v / host: %v / containerID: %v", mode, ipamConf.EtcdHost, containerID)
+	logging.Debugf("IPManagement -- mode: %v / host: %v / containerID: %v / podRef: %v", mode, ipamConf.EtcdHost, containerID, podRef)
 
 	var newip net.IPNet
 	// Skip invalid modes
@@ -92,7 +92,7 @@ RETRYLOOP:
 		var updatedreservelist []types.IPReservation
 		switch mode {
 		case types.Allocate:
-			newip, updatedreservelist, err = allocate.AssignIP(ipamConf, reservelist, containerID)
+			newip, updatedreservelist, err = allocate.AssignIP(ipamConf, reservelist, containerID, podRef)
 			if err != nil {
 				logging.Errorf("Error assigning IP: %v", err)
 				return newip, err

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -71,6 +71,7 @@ type Address struct {
 type IPReservation struct {
 	IP          net.IP `json:"ip"`
 	ContainerID string `json:"id"`
+	PodRef      string `json:"podref,omitempty"`
 }
 
 const (


### PR DESCRIPTION
As it is discussed in #75, some kind of cleaner mechanism is needed to release non-used IPs.

Whereabouts stores the ContainerID for each allocated IP. In case of Docker runtime that ContainerID is the ID of the **infra** container. The problem is that K8s does not register this infra container ID in the Pod descriptor, so later on we cannot determine which Pod owns which allocated IP (not considering the method about executing `docker ps` on every node to find out).

This PR would be the first step to resolve this issue by enriching the IPAllocation structure to store a Pod reference string (in `namespace/name` format). So later on a "cleaner" controller/script can walk through the IP allocation map and check whether each referenced Pod is still running or not. If a Pod is missing, it is safe to release its IP.

New IPPool example:
```
[..]
  spec:
    allocations:
      "1":
        id: 0c85206ce40fd429c62d1499c91f0fd5cb183fd610db3c4c458f167eaa0ee190
        podref: test/test-648b75d6fc-f56cp
      "2":
        id: 6442798c086abdad4c636b7c8e51f427511076a250e5434889b675c9e60bca06
        podref: test/test-648b75d6fc-sdbbm
      "3":
        id: c37586753ac82a69d7afbe73602020e7ecf4a93c666589d15cfb0108012e24ee
        podref: test/test-648b75d6fc-bhdjd
[..]
```

This new `podref` field is a description only for IPPool viewers. Its content is not considered during IP allocation/deallocation logic.