### PR TITLE
Remove bigint code to fix starts-with-zero-ipv6-problem

### DIFF
--- a/cmd/whereabouts_test.go
+++ b/cmd/whereabouts_test.go
@@ -162,6 +162,16 @@ var _ = Describe("Whereabouts operations", func() {
 		AllocateAndReleaseAddressesTest(ipVersion, ipRange, ipGateway, []string{expectedAddress}, whereaboutstypes.DatastoreKubernetes)
 	})
 
+	It("allocates and releases an IPv6 address with left-hand zeroes on ADD/DEL with a Kubernetes backend", func() {
+
+		ipVersion := "6"
+		ipRange := "fd::1/116"
+		ipGateway := "fd::f:1"
+		expectedAddress := "fd::1/116"
+
+		AllocateAndReleaseAddressesTest(ipVersion, ipRange, ipGateway, []string{expectedAddress}, whereaboutstypes.DatastoreKubernetes)
+	})
+
 	It("allocates IPv6 addresses with DNS-1123 conformant naming with a Kubernetes backend", func() {
 
 		ipVersion := "6"

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
-	github.com/go-logr/logr v0.1.0
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/google/btree v1.0.0 // indirect
 	github.com/google/uuid v1.1.1 // indirect

--- a/pkg/allocate/allocate.go
+++ b/pkg/allocate/allocate.go
@@ -71,11 +71,11 @@ func removeIdxFromSlice(s []types.IPReservation, i int) []types.IPReservation {
 	return s[:len(s)-1]
 }
 
-// byteSliseAdd adds ar1 to ar2
+// byteSliceAdd adds ar1 to ar2
 // note: ar1/ar2 should be 16-length array
-func byteSliseAdd(ar1, ar2 []byte) ([]byte, error) {
+func byteSliceAdd(ar1, ar2 []byte) ([]byte, error) {
 	if len(ar1) != len(ar2) {
-		return nil, fmt.Errorf("byteSliseAdd: bytes array mismatch: %v != %v", len(ar1), len(ar2))
+		return nil, fmt.Errorf("byteSliceAdd: bytes array mismatch: %v != %v", len(ar1), len(ar2))
 	}
 	carry := uint(0)
 
@@ -93,11 +93,11 @@ func byteSliseAdd(ar1, ar2 []byte) ([]byte, error) {
 	return sumByte, nil
 }
 
-// byteSliseSub subtract ar2 from ar1. This function assumes that ar1 > ar2
+// byteSliceSub subtracts ar2 from ar1. This function assumes that ar1 > ar2
 // note: ar1/ar2 should be 16-length array
-func byteSliseSub(ar1, ar2 []byte) ([]byte, error) {
+func byteSliceSub(ar1, ar2 []byte) ([]byte, error) {
 	if len(ar1) != len(ar2) {
-		return nil, fmt.Errorf("byteSliseSub: bytes array mismatch")
+		return nil, fmt.Errorf("byteSliceSub: bytes array mismatch")
 	}
 	carry := int(0)
 
@@ -151,7 +151,7 @@ func IPGetOffset(ip1, ip2 net.IP) uint64 {
 		return 0
 	}
 
-	ipOffset, _ := byteSliseSub([]byte(ip1.To16()), []byte(ip2.To16()))
+	ipOffset, _ := byteSliceSub([]byte(ip1.To16()), []byte(ip2.To16()))
 	return ipAddrToUint64(ipOffset)
 }
 
@@ -165,7 +165,7 @@ func IPAddOffset(ip net.IP, offset uint64) net.IP {
 	// make pseudo IP variable for offset
 	idxIP := ipAddrFromUint64(offset)
 
-	b, _ := byteSliseAdd([]byte(ip.To16()), []byte(idxIP))
+	b, _ := byteSliceAdd([]byte(ip.To16()), []byte(idxIP))
 	return net.IP(b)
 }
 

--- a/pkg/allocate/allocate.go
+++ b/pkg/allocate/allocate.go
@@ -206,6 +206,8 @@ func GetIPRange(ip net.IP, ipnet net.IPNet) (net.IP, net.IP, error) {
 	}
 	lastip := BigIntToIP(highestiplong)
 
+	logging.Debugf("!bang first/last: %v / %v", firstip, lastip)
+
 	return firstip, lastip, nil
 
 }
@@ -224,7 +226,7 @@ func BigIntToIP(inipint big.Int) net.IP {
 	var outip net.IP
 	outip = net.IP(make([]byte, net.IPv6len))
 	intbytes := inipint.Bytes()
-	if len(intbytes) == net.IPv6len {
+	if len(intbytes) > net.IPv4len+2 {
 		// This is an IPv6 address.
 		for i := 0; i < len(intbytes); i++ {
 			outip[i] = intbytes[i]
@@ -232,15 +234,40 @@ func BigIntToIP(inipint big.Int) net.IP {
 	} else {
 		// It's an IPv4 address.
 		for i := 0; i < len(intbytes); i++ {
+			// !bang WHY IS IT HAPPENING HERE!?
+			logging.Debugf("!bang, wtf: %v | ipv6len: %v | ipv4len: %v", len(intbytes), net.IPv6len, net.IPv4len)
 			outip[i+10] = intbytes[i]
 		}
 	}
+	logging.Debugf("!bang outip? %v", outip)
 	return outip
 }
 
 // IPToBigInt converts a net.IP to a big.Int
 func IPToBigInt(IPv6Addr net.IP) *big.Int {
 	IPv6Int := big.NewInt(0)
-	IPv6Int.SetBytes(IPv6Addr)
+	foo := []byte(IPv6Addr)
+	// shortholder := []byte()
+	// if len(foo) == net.IPv4len {
+	// 	if foo[0] == 0 {
+	// 		shortholder = []byte(0)
+	// 	}
+	// }
+	logging.Debugf("!bang foo: %v", foo)
+	logging.Debugf("!bang foo len: %v", len(foo))
+	IPv6Int.SetBytes(foo)
+	// !bang
+	// I need to figure out the byte size?
+	logging.Debugf("!bang binary: %b", IPv6Int)
+
+	if len(IPv6Int.Bytes()) > net.IPv4len+2 {
+		logging.Debugf("!bang what's the bytesize in IPToBigInt: %v", len(IPv6Int.Bytes()))
+		for i := net.IPv6len - len(IPv6Int.Bytes()); i > 0; i-- {
+			logging.Debugf("!bang HAPPENS ONCE!?")
+			// IPv6Int.Lsh(IPv6Int, uint(8))
+			// logging.Debugf("!bang after : %b", IPv6Int)
+		}
+	}
+
 	return IPv6Int
 }

--- a/pkg/allocate/allocate.go
+++ b/pkg/allocate/allocate.go
@@ -2,7 +2,7 @@ package allocate
 
 import (
 	"fmt"
-	"math/big"
+	"math"
 	"net"
 
 	"github.com/dougbtv/whereabouts/pkg/logging"
@@ -71,9 +71,106 @@ func removeIdxFromSlice(s []types.IPReservation, i int) []types.IPReservation {
 	return s[:len(s)-1]
 }
 
+// byteSliseAdd adds ar1 to ar2
+// note: ar1/ar2 should be 16-length array
+func byteSliseAdd(ar1, ar2 []byte) ([]byte, error) {
+	if len(ar1) != len(ar2) {
+		return nil, fmt.Errorf("byteSliseAdd: bytes array mismatch: %v != %v", len(ar1), len(ar2))
+	}
+	carry := uint(0)
+
+	sumByte := make([]byte, 16)
+	for n := range ar1 {
+		var sum uint
+		sum = uint(ar1[15-n]) + uint(ar2[15-n]) + carry
+		carry = 0
+		if sum > 255 {
+			carry = 1
+		}
+		sumByte[15-n] = uint8(sum)
+	}
+
+	return sumByte, nil
+}
+
+// byteSliseSub subtract ar2 from ar1. This function assumes that ar1 > ar2
+// note: ar1/ar2 should be 16-length array
+func byteSliseSub(ar1, ar2 []byte) ([]byte, error) {
+	if len(ar1) != len(ar2) {
+		return nil, fmt.Errorf("byteSliseSub: bytes array mismatch")
+	}
+	carry := int(0)
+
+	sumByte := make([]byte, 16)
+	for n := range ar1 {
+		var sum int
+		sum = int(ar1[15-n]) - int(ar2[15-n]) - carry
+		if sum < 0 {
+			sum = 0x100 - int(ar1[15-n]) - int(ar2[15-n]) - carry
+			carry = 1
+		} else {
+			carry = 0
+		}
+		sumByte[15-n] = uint8(sum)
+	}
+
+	return sumByte, nil
+}
+
+func ipAddrToUint64(ip net.IP) uint64 {
+	num := uint64(0)
+	ipArray := []byte(ip)
+	for n := range ipArray {
+		num = num << 8
+		num = uint64(ipArray[n]) + num
+	}
+	return num
+}
+
+func ipAddrFromUint64(num uint64) net.IP {
+	idxByte := make([]byte, 16)
+	i := num
+	for n := range idxByte {
+		idxByte[15-n] = byte(0xff & i)
+		i = i >> 8
+	}
+	return net.IP(idxByte)
+}
+
+// IPGetOffset gets offset between ip1 and ip2. This assumes ip1 > ip2 (from IP representation point of view)
+func IPGetOffset(ip1, ip2 net.IP) uint64 {
+	if ip1.To4() == nil && ip2.To4() != nil {
+		return 0
+	}
+
+	if ip1.To4() != nil && ip2.To4() == nil {
+		return 0
+	}
+
+	if len([]byte(ip1)) != len([]byte(ip2)) {
+		return 0
+	}
+
+	ipOffset, _ := byteSliseSub([]byte(ip1.To16()), []byte(ip2.To16()))
+	return ipAddrToUint64(ipOffset)
+}
+
+// IPAddOffset show IP address plus given offset
+func IPAddOffset(ip net.IP, offset uint64) net.IP {
+	// Check IPv4 and its offset range
+	if ip.To4() != nil && offset >= math.MaxUint32 {
+		return nil
+	}
+
+	// make pseudo IP variable for offset
+	idxIP := ipAddrFromUint64(offset)
+
+	b, _ := byteSliseAdd([]byte(ip.To16()), []byte(idxIP))
+	return net.IP(b)
+}
+
 // IterateForAssignment iterates given an IP/IPNet and a list of reserved IPs
 func IterateForAssignment(ipnet net.IPNet, rangeStart net.IP, rangeEnd net.IP, reservelist []types.IPReservation, excludeRanges []string, containerID string) (net.IP, []types.IPReservation, error) {
-
 	firstip := rangeStart
 	var lastip net.IP
 	if rangeEnd != nil {
@@ -90,10 +187,10 @@ func IterateForAssignment(ipnet net.IPNet, rangeStart net.IP, rangeEnd net.IP, r
 
 	reserved := make(map[string]bool)
 	for _, r := range reservelist {
-		ip := BigIntToIP(*IPToBigInt(r.IP))
-		reserved[ip.String()] = true
+		reserved[r.IP.String()] = true
 	}
 
+	// excluded,            "192.168.2.229/30", "192.168.1.229/30",
 	excluded := []*net.IPNet{}
 	for _, v := range excludeRanges {
 		_, subnet, _ := net.ParseCIDR(v)
@@ -103,37 +200,29 @@ func IterateForAssignment(ipnet net.IPNet, rangeStart net.IP, rangeEnd net.IP, r
 	// Iterate every IP address in the range
 	var assignedip net.IP
 	performedassignment := false
-MAINITERATION:
-	for i := IPToBigInt(firstip); IPToBigInt(lastip).Cmp(i) == 1 || IPToBigInt(lastip).Cmp(i) == 0; i.Add(i, big.NewInt(1)) {
-
-		assignedip = BigIntToIP(*i)
-		stringip := fmt.Sprint(assignedip)
-		// For each address see if it has been allocated
-		if reserved[stringip] {
-			// Continue if this IP is allocated.
+	endip := IPAddOffset(lastip, uint64(1))
+	for i := firstip; !i.Equal(endip); i = IPAddOffset(i, uint64(1)) {
+		// if already reserved, skip it
+		if reserved[i.String()] {
 			continue
 		}
 
-		// We can try to work with the current IP
-		// However, let's skip 0-based addresses in IPv4
-		ipbytes := i.Bytes()
-		if isIntIPv4(i) {
-			if ipbytes[5] == 0 {
-				continue
+		// Lastly, we need to check if this IP is within the range of excluded subnets
+		isAddrExcluded := false
+		for _, subnet := range excluded {
+			if subnet.Contains(i) {
+				isAddrExcluded = true
 			}
 		}
-
-		// Lastly, we need to check if this IP is within the range of excluded subnets
-		for _, subnet := range excluded {
-			if subnet.Contains(BigIntToIP(*i).To16()) {
-				continue MAINITERATION
-			}
+		if isAddrExcluded {
+			continue
 		}
 
 		// Ok, this one looks like we can assign it!
 		performedassignment = true
 
-		logging.Debugf("Reserving IP: |%v|", stringip+" "+containerID)
+		assignedip = i
+		logging.Debugf("Reserving IP: |%v|", assignedip.String()+" "+containerID)
 		reservelist = append(reservelist, types.IPReservation{IP: assignedip, ContainerID: containerID})
 		break
 	}
@@ -145,12 +234,19 @@ MAINITERATION:
 	return assignedip, reservelist, nil
 }
 
+func mergeIPAddress(net, host []byte) ([]byte, error) {
+	if len(net) != len(host) {
+		return nil, fmt.Errorf("not matched")
+	}
+	addr := append([]byte{}, net...)
+	for i := range net {
+		addr[i] = net[i] | host[i]
+	}
+	return addr, nil
+}
+
 // GetIPRange returns the first and last IP in a range
 func GetIPRange(ip net.IP, ipnet net.IPNet) (net.IP, net.IP, error) {
-
-	// Good hints here: http://networkbit.ch/golang-ip-address-manipulation/
-	// Nice info on bitwise operations: https://yourbasic.org/golang/bitwise-operator-cheat-sheet/
-	// Get info about the mask.
 	mask := ipnet.Mask
 	ones, bits := mask.Size()
 	masklen := bits - ones
@@ -160,114 +256,34 @@ func GetIPRange(ip net.IP, ipnet net.IPNet) (net.IP, net.IP, error) {
 		return nil, nil, fmt.Errorf("Net mask is too short, must be 2 or more: %v", masklen)
 	}
 
-	// Get a long from the current IP address
-	longip := IPToBigInt(ip)
-
-	// Shift out to get the lowest IP value.
-	var lowestiplong big.Int
-	lowestiplong.Rsh(longip, uint(masklen))
-	lowestiplong.Lsh(&lowestiplong, uint(masklen))
-
-	// Get the mask as a long, shift it out
-	var masklong big.Int
-	// We need to generate the largest number...
-	// Let's try to figure out if it's IPv4 or v6
-	var maxval big.Int
-	if len(lowestiplong.Bytes()) == net.IPv6len {
-		// It's v6
-		// Maximum IPv6 value: 0xffffffffffffffffffffffffffffffff
-		maxval.SetString("0xffffffffffffffffffffffffffffffff", 0)
-	} else {
-		// It's v4
-		// Maximum IPv4 value: 4294967295
-		maxval.SetUint64(4294967295)
+	// get network part
+	network := ip.Mask(ipnet.Mask)
+	// get bitmask for host
+	hostMask := net.IPMask(append([]byte{}, ipnet.Mask...))
+	for i, n := range hostMask {
+		hostMask[i] = ^n
 	}
-
-	masklong.Rsh(&maxval, uint(ones))
-
-	// Now figure out the highest value...
-	// We can OR that value...
-	var highestiplong big.Int
-	highestiplong.Or(&lowestiplong, &masklong)
-	// remove network and broadcast address from the  range
-	var incIP big.Int
-	incIP.SetInt64(1)
-	// removes network address
-	lowestiplong.Add(&lowestiplong, &incIP)
-	// remove broadcast address, only when IPv4 (IPv6 doesn't have broadcast addresses)
-	if IsIPv4(ip) {
-		highestiplong.Sub(&highestiplong, &incIP)
+	// get host part of ip
+	first := ip.Mask(net.IPMask(hostMask))
+	// if ip is just same as ipnet.IP, i.e. just network address,
+	// increment it for start ip
+	if ip.Equal(ipnet.IP) {
+		first[len(first)-1] = 0x1
 	}
-
-	// Convert to net.IPs
-	firstip := BigIntToIP(lowestiplong)
-	if lowestiplong.Cmp(longip) < 0 { // if range_start was provided and its greater.
-		firstip = BigIntToIP(*longip)
+	// calculate last byte
+	last := hostMask
+	// if IPv4 case, decrement 1 for broadcasting address
+	if ip.To4() != nil {
+		last[len(last)-1]--
 	}
-	lastip := BigIntToIP(highestiplong)
+	// get first ip and last ip based on network part + host part
+	firstIP, _ := mergeIPAddress([]byte(network), first)
+	lastIP, _ := mergeIPAddress([]byte(network), last)
 
-	logging.Debugf("!bang first/last: %v / %v", firstip, lastip)
-
-	return firstip, lastip, nil
-
+	return firstIP, lastIP, nil
 }
 
 // IsIPv4 checks if an IP is v4.
 func IsIPv4(checkip net.IP) bool {
 	return checkip.To4() != nil
-}
-
-func isIntIPv4(checkipint *big.Int) bool {
-	return !(len(checkipint.Bytes()) == net.IPv6len)
-}
-
-// BigIntToIP converts a big.Int to a net.IP
-func BigIntToIP(inipint big.Int) net.IP {
-	var outip net.IP
-	outip = net.IP(make([]byte, net.IPv6len))
-	intbytes := inipint.Bytes()
-	if len(intbytes) > net.IPv4len+2 {
-		// This is an IPv6 address.
-		for i := 0; i < len(intbytes); i++ {
-			outip[i] = intbytes[i]
-		}
-	} else {
-		// It's an IPv4 address.
-		for i := 0; i < len(intbytes); i++ {
-			// !bang WHY IS IT HAPPENING HERE!?
-			logging.Debugf("!bang, wtf: %v | ipv6len: %v | ipv4len: %v", len(intbytes), net.IPv6len, net.IPv4len)
-			outip[i+10] = intbytes[i]
-		}
-	}
-	logging.Debugf("!bang outip? %v", outip)
-	return outip
-}
-
-// IPToBigInt converts a net.IP to a big.Int
-func IPToBigInt(IPv6Addr net.IP) *big.Int {
-	IPv6Int := big.NewInt(0)
-	foo := []byte(IPv6Addr)
-	// shortholder := []byte()
-	// if len(foo) == net.IPv4len {
-	// 	if foo[0] == 0 {
-	// 		shortholder = []byte(0)
-	// 	}
-	// }
-	logging.Debugf("!bang foo: %v", foo)
-	logging.Debugf("!bang foo len: %v", len(foo))
-	IPv6Int.SetBytes(foo)
-	// !bang
-	// I need to figure out the byte size?
-	logging.Debugf("!bang binary: %b", IPv6Int)
-
-	if len(IPv6Int.Bytes()) > net.IPv4len+2 {
-		logging.Debugf("!bang what's the bytesize in IPToBigInt: %v", len(IPv6Int.Bytes()))
-		for i := net.IPv6len - len(IPv6Int.Bytes()); i > 0; i-- {
-			logging.Debugf("!bang HAPPENS ONCE!?")
-			// IPv6Int.Lsh(IPv6Int, uint(8))
-			// logging.Debugf("!bang after : %b", IPv6Int)
-		}
-	}
-
-	return IPv6Int
 }

--- a/pkg/allocate/allocate_test.go
+++ b/pkg/allocate/allocate_test.go
@@ -2,6 +2,8 @@ package allocate
 
 import (
 	"fmt"
+	"github.com/dougbtv/whereabouts/pkg/types"
+	"math"
 	"math/big"
 	"net"
 	"testing"
@@ -14,6 +16,152 @@ func TestAllocate(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "cmd")
 }
+
+var _ = Describe("Allocation utility functions", func() {
+	/*
+		func byteSliseAdd(ar1, ar2 []byte) ([]byte, error) {
+		func byteSliseSub(ar1, ar2 []byte) ([]byte, error) {
+		func ipAddrToUint64(ip net.IP) uint64 {
+		func ipAddrFromUint64(num uint64) net.IP {
+		func IPAddOffset(ip net.IP, offset uint64) net.IP {
+		func IPGetOffset(ip1, ip2 net.IP) uint64 {
+	*/
+	It("tests byteSliceAdd normal case", func() {
+		b1 := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1}
+		b2 := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10}
+		bSum, err := byteSliseAdd(b1, b2)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bSum).To(Equal([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 11}))
+	})
+
+	It("tests byteSliceAdd carry case", func() {
+		b1 := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255}
+		b2 := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+		bSum, err := byteSliseAdd(b1, b2)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bSum).To(Equal([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0}))
+	})
+
+	It("tests byteSliceSub normal case", func() {
+		b1 := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10}
+		b2 := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1}
+		bSum, err := byteSliseSub(b1, b2)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bSum).To(Equal([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9, 9}))
+	})
+
+	It("tests byteSliceSub carry case", func() {
+		b1 := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0}
+		b2 := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+		bSum, err := byteSliseSub(b1, b2)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bSum).To(Equal([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255}))
+	})
+
+	It("ipAddrToUint64", func() {
+		b := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 255, 255}
+		bNum := ipAddrToUint64(net.IP(b))
+		Expect(bNum).To(Equal(uint64(0x1ffff)))
+	})
+
+	It("ipAddrFromUint64", func() {
+		uintNum := uint64(0x1ffff)
+		ip := net.IP([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 255, 255})
+		bNum := ipAddrFromUint64(uintNum)
+		Expect(bNum).To(Equal(ip))
+	})
+
+	It("IPAddOffset normal case", func() {
+		ip1 := net.ParseIP("192.168.2.23")
+		ip2 := IPAddOffset(ip1, uint64(1))
+		Expect(ip2).To(Equal(net.ParseIP("192.168.2.24")))
+
+		ip3 := net.ParseIP("ff02::1")
+		ip4 := IPAddOffset(ip3, uint64(1))
+		Expect(ip4).To(Equal(net.ParseIP("ff02::2")))
+	})
+
+	It("IPAddOffset carry case", func() {
+		ip1 := net.ParseIP("192.168.2.255")
+		ip2 := IPAddOffset(ip1, uint64(1))
+		Expect(ip2).To(Equal(net.ParseIP("192.168.3.0")))
+
+		ip3 := net.ParseIP("192.168.255.255")
+		ip4 := IPAddOffset(ip3, uint64(1))
+		Expect(ip4).To(Equal(net.ParseIP("192.169.0.0")))
+
+		ip5 := net.ParseIP("ff02::ff")
+		ip6 := IPAddOffset(ip5, uint64(1))
+		Expect(ip6).To(Equal(net.ParseIP("ff02::0:100")))
+
+		ip7 := net.ParseIP("ff02::ffff")
+		ip8 := IPAddOffset(ip7, uint64(1))
+		Expect(ip8).To(Equal(net.ParseIP("ff02::1:0")))
+
+		ip9 := net.ParseIP("ff02::ffff:ffff")
+		ip10 := IPAddOffset(ip9, uint64(1))
+		Expect(ip10).To(Equal(net.ParseIP("ff02::1:0:0")))
+	})
+
+	It("IPAddOffset error case", func() {
+		ip1 := net.ParseIP("192.168.2.255")
+		ip2 := IPAddOffset(ip1, uint64(math.MaxUint32+1))
+		Expect(ip2).To(BeNil())
+
+		ip3 := net.ParseIP("ff02::1")
+		ip4 := IPAddOffset(ip3, uint64(math.MaxUint32+1))
+		Expect(ip4).NotTo(BeNil())
+	})
+
+	It("IPGetOffset normal case", func() {
+		ip1 := net.ParseIP("192.168.2.255")
+		ip2 := net.ParseIP("192.168.2.1")
+		offset1 := IPGetOffset(ip1, ip2)
+		Expect(offset1).To(Equal(uint64(254)))
+
+		ip3 := net.ParseIP("ff02::ff")
+		ip4 := net.ParseIP("ff02::1")
+		offset2 := IPGetOffset(ip3, ip4)
+		Expect(offset2).To(Equal(uint64(254)))
+	})
+
+	It("IPGetOffset carry case", func() {
+		ip1 := net.ParseIP("192.168.3.0")
+		ip2 := net.ParseIP("192.168.2.1")
+		offset1 := IPGetOffset(ip1, ip2)
+		Expect(offset1).To(Equal(uint64(255)))
+
+		ip3 := net.ParseIP("ff02::100")
+		ip4 := net.ParseIP("ff02::1")
+		offset2 := IPGetOffset(ip3, ip4)
+		Expect(offset2).To(Equal(uint64(255)))
+
+		ip5 := net.ParseIP("ff02::1:0")
+		ip6 := net.ParseIP("ff02::1")
+		offset3 := IPGetOffset(ip5, ip6)
+		Expect(offset3).To(Equal(uint64(0xffff)))
+	})
+
+	It("IPGetOffset error case", func() {
+		// cannot get offset from v4/v6
+		ip1 := net.ParseIP("192.168.3.0")
+		ip2 := net.ParseIP("ff02::1")
+		offset1 := IPGetOffset(ip1, ip2)
+		Expect(offset1).To(Equal(uint64(0)))
+
+		// cannot get offset from v6/v4
+		ip3 := net.ParseIP("ff02::1")
+		ip4 := net.ParseIP("192.168.3.0")
+		offset2 := IPGetOffset(ip3, ip4)
+		Expect(offset2).To(Equal(uint64(0)))
+
+		// cannot get offset between different length array (ar[4] and ar[16])
+		ip5 := net.ParseIP("192.168.4.0")
+		ip6 := net.ParseIP("192.168.3.0")
+		offset3 := IPGetOffset(ip5.To4(), ip6)
+		Expect(offset3).To(Equal(uint64(0)))
+	})
+})
 
 var _ = Describe("Allocation operations", func() {
 	It("creates an IPv4 range properly for 30 bits network address", func() {
@@ -86,7 +234,7 @@ var _ = Describe("Allocation operations", func() {
 
 	})
 
-	It("creates an IPv6 range when the first hextets's zeroes have been shortened", func() {
+	It("creates an IPv6 range when the first hextet has leading zeroes", func() {
 
 		ip, ipnet, err := net.ParseCIDR("fd:db8:abcd:0012::0/96")
 		ip, _ = AddressRange(ipnet)
@@ -100,42 +248,84 @@ var _ = Describe("Allocation operations", func() {
 		Expect(fmt.Sprint(lastip)).To(Equal("fd:db8:abcd:12::ffff:ffff"))
 
 	})
-	It("!bang THIS DOESN'T WORK: creates an IPv6 range properly for 112 bits network address", func() {
 
-		//                               00fd:0100:0200:0030:0371:0000:0000:0000/112
-		// ip, ipnet, err := net.ParseCIDR("fd:100:200:30:371::0/112")
-		// ip, ipnet, err := net.ParseCIDR("fd:100:200:30:371::0/112")
-		ip, ipnet, err := net.ParseCIDR("fd:100:200:30:371::0/112")
-		// ip, ipnet, err := net.ParseCIDR("2001:0100:0200:0030:0371:0000:0000:0000/112")
-		ip, _ = AddressRange(ipnet)
+	It("can IterateForAssignment on an IPv4 address", func() {
 
+		firstip, ipnet, err := net.ParseCIDR("192.168.1.1/24")
 		Expect(err).NotTo(HaveOccurred())
 
-		firstip, lastip, err := GetIPRange(net.ParseIP(ip.String()), *ipnet)
-		Expect(err).NotTo(HaveOccurred())
+		// figure out the range start.
+		calculatedrangestart := net.ParseIP(firstip.Mask(ipnet.Mask).String())
 
-		Expect(fmt.Sprint(firstip)).To(Equal("fd:100:200:30:371::1"))
-		Expect(fmt.Sprint(lastip)).To(Equal("fd:100:200:30:371::ffff"))
+		var ipres []types.IPReservation
+		var exrange []string
+		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef")
+		Expect(fmt.Sprint(newip)).To(Equal("192.168.1.1"))
 
 	})
-	It("!bang THIS WORKS... creates an IPv6 range properly for 112 bits network address", func() {
 
-		//                               00fd:0100:0200:0030:0371:0000:0000:0000/112
-		// ip, ipnet, err := net.ParseCIDR("fd:100:200:30:371::0/112")
-		// ip, ipnet, err := net.ParseCIDR("fd:100:200:30:371::0/112")
-		// ip, ipnet, err := net.ParseCIDR("fd:100:200:30:371::0/112")
-		ip, ipnet, err := net.ParseCIDR("2001:0100:0200:0030:0371:0000:0000:0000/112")
-		ip, _ = AddressRange(ipnet)
+	It("can IterateForAssignment on an IPv6 address when the first hextet has NO leading zeroes", func() {
 
+		firstip, ipnet, err := net.ParseCIDR("caa5::0/112")
 		Expect(err).NotTo(HaveOccurred())
 
-		firstip, lastip, err := GetIPRange(net.ParseIP(ip.String()), *ipnet)
-		Expect(err).NotTo(HaveOccurred())
+		// figure out the range start.
+		calculatedrangestart := net.ParseIP(firstip.Mask(ipnet.Mask).String())
 
-		Expect(fmt.Sprint(firstip)).To(Equal("2001:100:200:30:371::1"))
-		Expect(fmt.Sprint(lastip)).To(Equal("2001:100:200:30:371::ffff"))
+		var ipres []types.IPReservation
+		var exrange []string
+		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef")
+		Expect(fmt.Sprint(newip)).To(Equal("caa5::1"))
 
 	})
+
+	It("can IterateForAssignment on an IPv6 address when the first hextet has ALL leading zeroes", func() {
+
+		firstip, ipnet, err := net.ParseCIDR("::1/126")
+		Expect(err).NotTo(HaveOccurred())
+
+		// figure out the range start.
+		calculatedrangestart := net.ParseIP(firstip.Mask(ipnet.Mask).String())
+
+		var ipres []types.IPReservation
+		var exrange []string
+		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef")
+		Expect(fmt.Sprint(newip)).To(Equal("::1"))
+
+	})
+
+	//
+
+	It("can IterateForAssignment on an IPv6 address when the first hextet has TWO leading zeroes", func() {
+
+		firstip, ipnet, err := net.ParseCIDR("fd::1/116")
+		Expect(err).NotTo(HaveOccurred())
+
+		// figure out the range start.
+		calculatedrangestart := net.ParseIP(firstip.Mask(ipnet.Mask).String())
+
+		var ipres []types.IPReservation
+		var exrange []string
+		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef")
+		Expect(fmt.Sprint(newip)).To(Equal("fd::1"))
+
+	})
+
+	It("can IterateForAssignment on an IPv6 address when the first hextet has leading zeroes", func() {
+
+		firstip, ipnet, err := net.ParseCIDR("100::2:1/126")
+		Expect(err).NotTo(HaveOccurred())
+
+		// figure out the range start.
+		calculatedrangestart := net.ParseIP(firstip.Mask(ipnet.Mask).String())
+
+		var ipres []types.IPReservation
+		var exrange []string
+		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef")
+		Expect(fmt.Sprint(newip)).To(Equal("100::2:1"))
+
+	})
+
 	It("creates an IPv6 range properly for 96 bits network address", func() {
 
 		ip, ipnet, err := net.ParseCIDR("2001:db8:abcd:0012::0/96")
@@ -185,7 +375,6 @@ var _ = Describe("Allocation operations", func() {
 		Expect(err.Error()).To(HavePrefix("Net mask is too short"))
 
 	})
-
 })
 
 func AddressRange(network *net.IPNet) (net.IP, net.IP) {

--- a/pkg/allocate/allocate_test.go
+++ b/pkg/allocate/allocate_test.go
@@ -85,6 +85,57 @@ var _ = Describe("Allocation operations", func() {
 		Expect(fmt.Sprint(lastip)).To(Equal("2001::fff"))
 
 	})
+
+	It("creates an IPv6 range when the first hextets's zeroes have been shortened", func() {
+
+		ip, ipnet, err := net.ParseCIDR("fd:db8:abcd:0012::0/96")
+		ip, _ = AddressRange(ipnet)
+
+		Expect(err).NotTo(HaveOccurred())
+
+		firstip, lastip, err := GetIPRange(net.ParseIP(ip.String()), *ipnet)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(fmt.Sprint(firstip)).To(Equal("fd:db8:abcd:12::1"))
+		Expect(fmt.Sprint(lastip)).To(Equal("fd:db8:abcd:12::ffff:ffff"))
+
+	})
+	It("!bang THIS DOESN'T WORK: creates an IPv6 range properly for 112 bits network address", func() {
+
+		//                               00fd:0100:0200:0030:0371:0000:0000:0000/112
+		// ip, ipnet, err := net.ParseCIDR("fd:100:200:30:371::0/112")
+		// ip, ipnet, err := net.ParseCIDR("fd:100:200:30:371::0/112")
+		ip, ipnet, err := net.ParseCIDR("fd:100:200:30:371::0/112")
+		// ip, ipnet, err := net.ParseCIDR("2001:0100:0200:0030:0371:0000:0000:0000/112")
+		ip, _ = AddressRange(ipnet)
+
+		Expect(err).NotTo(HaveOccurred())
+
+		firstip, lastip, err := GetIPRange(net.ParseIP(ip.String()), *ipnet)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(fmt.Sprint(firstip)).To(Equal("fd:100:200:30:371::1"))
+		Expect(fmt.Sprint(lastip)).To(Equal("fd:100:200:30:371::ffff"))
+
+	})
+	It("!bang THIS WORKS... creates an IPv6 range properly for 112 bits network address", func() {
+
+		//                               00fd:0100:0200:0030:0371:0000:0000:0000/112
+		// ip, ipnet, err := net.ParseCIDR("fd:100:200:30:371::0/112")
+		// ip, ipnet, err := net.ParseCIDR("fd:100:200:30:371::0/112")
+		// ip, ipnet, err := net.ParseCIDR("fd:100:200:30:371::0/112")
+		ip, ipnet, err := net.ParseCIDR("2001:0100:0200:0030:0371:0000:0000:0000/112")
+		ip, _ = AddressRange(ipnet)
+
+		Expect(err).NotTo(HaveOccurred())
+
+		firstip, lastip, err := GetIPRange(net.ParseIP(ip.String()), *ipnet)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(fmt.Sprint(firstip)).To(Equal("2001:100:200:30:371::1"))
+		Expect(fmt.Sprint(lastip)).To(Equal("2001:100:200:30:371::ffff"))
+
+	})
 	It("creates an IPv6 range properly for 96 bits network address", func() {
 
 		ip, ipnet, err := net.ParseCIDR("2001:db8:abcd:0012::0/96")

--- a/pkg/allocate/allocate_test.go
+++ b/pkg/allocate/allocate_test.go
@@ -19,8 +19,8 @@ func TestAllocate(t *testing.T) {
 
 var _ = Describe("Allocation utility functions", func() {
 	/*
-		func byteSliseAdd(ar1, ar2 []byte) ([]byte, error) {
-		func byteSliseSub(ar1, ar2 []byte) ([]byte, error) {
+		func byteSliceAdd(ar1, ar2 []byte) ([]byte, error) {
+		func byteSliceSub(ar1, ar2 []byte) ([]byte, error) {
 		func ipAddrToUint64(ip net.IP) uint64 {
 		func ipAddrFromUint64(num uint64) net.IP {
 		func IPAddOffset(ip net.IP, offset uint64) net.IP {
@@ -29,7 +29,7 @@ var _ = Describe("Allocation utility functions", func() {
 	It("tests byteSliceAdd normal case", func() {
 		b1 := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1}
 		b2 := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10}
-		bSum, err := byteSliseAdd(b1, b2)
+		bSum, err := byteSliceAdd(b1, b2)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(bSum).To(Equal([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 11}))
 	})
@@ -37,7 +37,7 @@ var _ = Describe("Allocation utility functions", func() {
 	It("tests byteSliceAdd carry case", func() {
 		b1 := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255}
 		b2 := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
-		bSum, err := byteSliseAdd(b1, b2)
+		bSum, err := byteSliceAdd(b1, b2)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(bSum).To(Equal([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0}))
 	})
@@ -45,7 +45,7 @@ var _ = Describe("Allocation utility functions", func() {
 	It("tests byteSliceSub normal case", func() {
 		b1 := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10}
 		b2 := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1}
-		bSum, err := byteSliseSub(b1, b2)
+		bSum, err := byteSliceSub(b1, b2)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(bSum).To(Equal([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9, 9}))
 	})
@@ -53,25 +53,25 @@ var _ = Describe("Allocation utility functions", func() {
 	It("tests byteSliceSub carry case", func() {
 		b1 := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0}
 		b2 := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
-		bSum, err := byteSliseSub(b1, b2)
+		bSum, err := byteSliceSub(b1, b2)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(bSum).To(Equal([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255}))
 	})
 
-	It("ipAddrToUint64", func() {
+	It("can convert ipAddrToUint64", func() {
 		b := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 255, 255}
 		bNum := ipAddrToUint64(net.IP(b))
 		Expect(bNum).To(Equal(uint64(0x1ffff)))
 	})
 
-	It("ipAddrFromUint64", func() {
+	It("can convert ipAddrFromUint64", func() {
 		uintNum := uint64(0x1ffff)
 		ip := net.IP([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 255, 255})
 		bNum := ipAddrFromUint64(uintNum)
 		Expect(bNum).To(Equal(ip))
 	})
 
-	It("IPAddOffset normal case", func() {
+	It("confirms the IPAddOffset normal case", func() {
 		ip1 := net.ParseIP("192.168.2.23")
 		ip2 := IPAddOffset(ip1, uint64(1))
 		Expect(ip2).To(Equal(net.ParseIP("192.168.2.24")))
@@ -81,7 +81,7 @@ var _ = Describe("Allocation utility functions", func() {
 		Expect(ip4).To(Equal(net.ParseIP("ff02::2")))
 	})
 
-	It("IPAddOffset carry case", func() {
+	It("confirms the IPAddOffset carry case", func() {
 		ip1 := net.ParseIP("192.168.2.255")
 		ip2 := IPAddOffset(ip1, uint64(1))
 		Expect(ip2).To(Equal(net.ParseIP("192.168.3.0")))
@@ -103,7 +103,7 @@ var _ = Describe("Allocation utility functions", func() {
 		Expect(ip10).To(Equal(net.ParseIP("ff02::1:0:0")))
 	})
 
-	It("IPAddOffset error case", func() {
+	It("confirms the IPAddOffset error case", func() {
 		ip1 := net.ParseIP("192.168.2.255")
 		ip2 := IPAddOffset(ip1, uint64(math.MaxUint32+1))
 		Expect(ip2).To(BeNil())
@@ -113,7 +113,7 @@ var _ = Describe("Allocation utility functions", func() {
 		Expect(ip4).NotTo(BeNil())
 	})
 
-	It("IPGetOffset normal case", func() {
+	It("confirms the IPGetOffset normal case", func() {
 		ip1 := net.ParseIP("192.168.2.255")
 		ip2 := net.ParseIP("192.168.2.1")
 		offset1 := IPGetOffset(ip1, ip2)
@@ -125,7 +125,7 @@ var _ = Describe("Allocation utility functions", func() {
 		Expect(offset2).To(Equal(uint64(254)))
 	})
 
-	It("IPGetOffset carry case", func() {
+	It("confirms the IPGetOffset carry case", func() {
 		ip1 := net.ParseIP("192.168.3.0")
 		ip2 := net.ParseIP("192.168.2.1")
 		offset1 := IPGetOffset(ip1, ip2)
@@ -142,7 +142,7 @@ var _ = Describe("Allocation utility functions", func() {
 		Expect(offset3).To(Equal(uint64(0xffff)))
 	})
 
-	It("IPGetOffset error case", func() {
+	It("confirms the IPGetOffset error case", func() {
 		// cannot get offset from v4/v6
 		ip1 := net.ParseIP("192.168.3.0")
 		ip2 := net.ParseIP("ff02::1")

--- a/pkg/storage/kubernetes.go
+++ b/pkg/storage/kubernetes.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/big"
 	"net"
 	"strconv"
 	"strings"
@@ -72,27 +71,24 @@ type KubernetesIPAM struct {
 
 func toIPReservationList(allocations map[string]whereaboutsv1alpha1.IPAllocation, firstip net.IP) []whereaboutstypes.IPReservation {
 	reservelist := []whereaboutstypes.IPReservation{}
-	i := allocate.IPToBigInt(firstip)
 	for offset, a := range allocations {
-		ipOffset, err := strconv.ParseInt(offset, 10, 64)
+		numOffset, err := strconv.ParseInt(offset, 10, 64)
 		if err != nil {
 			// allocations that are invalid int64s should be ignored
 			// toAllocationMap should be the only writer of offsets, via `fmt.Sprintf("%d", ...)``
 			logging.Errorf("Error decoding ip offset (backend: kubernetes): %v", err)
 			continue
 		}
-		ip := allocate.BigIntToIP(*big.NewInt(0).Add(i, big.NewInt(ipOffset)))
+		ip := allocate.IPAddOffset(firstip, uint64(numOffset))
 		reservelist = append(reservelist, whereaboutstypes.IPReservation{IP: ip, ContainerID: a.ContainerID})
 	}
 	return reservelist
 }
 
 func toAllocationMap(reservelist []whereaboutstypes.IPReservation, firstip net.IP) map[string]whereaboutsv1alpha1.IPAllocation {
-	first := allocate.IPToBigInt(firstip)
 	allocations := make(map[string]whereaboutsv1alpha1.IPAllocation)
 	for _, r := range reservelist {
-		currentip := allocate.IPToBigInt(r.IP)
-		index := currentip.Sub(currentip, first).Int64()
+		index := allocate.IPGetOffset(r.IP, firstip)
 		allocations[fmt.Sprintf("%d", index)] = whereaboutsv1alpha1.IPAllocation{ContainerID: r.ContainerID}
 	}
 	return allocations


### PR DESCRIPTION
Fix #84
This code removes bigint from pkg/allocate because it may causes various problem.