### PR TITLE
feat: add arm64 dockerfile and add github action steps for new arch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
       matrix:
         go-version: [1.15.x, 1.16.x]
         #goarch: [386, amd64, arm, ppc64le, arm64]
-        goarch: [amd64]
+        goarch: [amd64, arm64]
         os: [ubuntu-latest] #, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -37,7 +37,7 @@ jobs:
           tags: dougbtv/whereabouts-ocp
           file: Dockerfile.openshift
 
-  build-amd64:
+  build-arm64:
     name: Image build/arm64
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -36,3 +36,21 @@ jobs:
           push: false
           tags: dougbtv/whereabouts-ocp
           file: Dockerfile.openshift
+
+  build-amd64:
+    name: Image build/arm64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build container image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: false
+          tags: dougbtv/whereabouts:latest-arm64
+          file: Dockerfile.arm64

--- a/.github/workflows/image-push-release.yml
+++ b/.github/workflows/image-push-release.yml
@@ -41,3 +41,39 @@ jobs:
           tags: |
             ${{ steps.docker_meta.outputs.tags }}-amd64
           file: deployments/Dockerfile
+
+  push-arm64:
+    name: Image push/arm64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Container Registry
+        if: github.repository_owner == 'dougbtv'
+        uses: docker/login-action@v1
+        with:
+          #registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          #images: ghcr.io/${{ github.repository }}
+          images: dougbtv/whereabouts
+          tag-latest: false
+
+      - name: Push container image
+        if: github.repository_owner == 'dougbtv'
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}-arm64
+          file: deployments/Dockerfile

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,15 @@
+FROM golang:1.13
+ADD . /usr/src/whereabouts
+
+ENV GOARCH "arm64"
+ENV GOOS "linux"
+
+RUN mkdir -p $GOPATH/src/github.com/dougbtv/whereabouts
+WORKDIR $GOPATH/src/github.com/dougbtv/whereabouts
+COPY . .
+RUN ./hack/build-go.sh
+
+FROM arm64v8/alpine:latest
+COPY --from=0 /go/src/github.com/dougbtv/whereabouts/bin/whereabouts .
+COPY script/install-cni.sh .
+CMD ["/install-cni.sh"]


### PR DESCRIPTION
**Problem:**  

- When testing with k3s cluster and pi4 targets (arm64), this where-aboot project does not work in Canada. :canada:

**Key Features:**

- Provides `Dockerfile.arm64` to create arm64 compatible docker images
- Github actions to build image

**Notes:**
- Tested local docker build only, not yet deployed against k3s cluster.

